### PR TITLE
Add complete Norwegian language support

### DIFF
--- a/res/values-nb/strings_murine.xml
+++ b/res/values-nb/strings_murine.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="pref_group_grid_size_title">Rutenettstørrelse</string>
+    <string name="pref_group_grid_size_desc">Endre antall rader og kolonner</string>
+    <string name="pref_group_icon_scale_title">Ikonskalering</string>
+    <string name="pref_group_icon_scale_desc">Endre størrelsen på ikoner og etiketter</string>
+    <string name="pref_group_qsb_transparency">Gjennomsiktighet</string>
+    <string name="pref_group_qsb_transparency_desc">Angi gjennomsiktighet for hurtigsøkefeltet</string>
+
+    <string name="pref_category_general_title">Generelt</string>
+    <string name="pref_category_general_desc">Globale innstillinger</string>
+    <string name="pref_category_icons_title">Ikoner</string>
+    <string name="pref_category_icons_desc">Angi ikonstørrelse og utseende</string>
+    <string name="pref_category_home_title">Startskjerm</string>
+    <string name="pref_category_home_desc">Tilpass startskjermen</string>
+    <string name="pref_category_drawer_title">Appskuff</string>
+    <string name="pref_category_drawer_desc">Tilpass appskuffen</string>
+    <string name="pref_category_qsb_title">Søk</string>
+    <string name="pref_category_qsb_desc">Tilpass hurtigsøkefeltet</string>
+    <string name="pref_category_misc_title">Diverse</string>
+    <string name="pref_category_misc_desc">Andre alternativer</string>
+
+    <string name="pref_subcategory_day_night">Grensesnittstema</string>
+    <string name="pref_subcategory_language">Språk</string>
+    <string name="pref_subcategory_layout">Oppsett</string>
+    <string name="pref_subcategory_appearance">Utseende</string>
+    <string name="pref_subcategory_persistency">Lagring</string>
+    <string name="pref_subcategory_gestures">Bevegelser</string>
+    <string name="pref_subcategory_options">Alternativer</string>
+    <string name="pref_subcategory_backup">Sikkerhetskopi</string>
+
+    <string name="pref_language_title">Språk</string>
+    <string name="pref_language_system">Systemstandard</string>
+    <string name="pref_language_norwegian">Norsk</string>
+    <string name="pref_language_english">Engelsk</string>
+    <string-array name="pref_language_entries">
+        <item>@string/pref_language_system</item>
+        <item>@string/pref_language_norwegian</item>
+        <item>@string/pref_language_english</item>
+    </string-array>
+
+    <string name="backup_export_title">Eksporter sikkerhetskopi</string>
+    <string name="backup_export_desc">Lagre oppsett, moduler og innstillinger</string>
+    <string name="backup_export_done">Sikkerhetskopien er lagret</string>
+    <string name="backup_import_title">Gjenopprett sikkerhetskopi</string>
+    <string name="backup_import_desc">Gjenopprett lagret oppsett og innstillinger</string>
+    <string name="backup_import_confirm">Dette starter launcheren på nytt og gjenoppretter oppsettet ditt</string>
+
+    <string name="pref_label_ui_mode_system">System</string>
+    <string name="pref_label_ui_mode_day">Lyst</string>
+    <string name="pref_label_ui_mode_night">Mørkt</string>
+    <string name="pref_label_grid_width">Rutenettbredde</string>
+    <string name="pref_label_grid_height">Rutenetthøyde</string>
+    <string name="pref_label_icon_size">Ikonstørrelse (%)</string>
+    <string name="pref_label_icon_label_size">Etikettstørrelse (%)</string>
+
+    <string name="pref_label_visibility_title">Visning av etiketter</string>
+    <string name="label_visibility_never">Aldri</string>
+    <string name="label_visibility_auto">Automatisk</string>
+    <string name="label_visibility_always">Alltid</string>
+
+    <string name="pref_icon_shape_title">Ikonform</string>
+    <string name="icon_shape_system">System</string>
+    <string name="icon_shape_circle">Sirkel</string>
+    <string name="icon_shape_tofu">Tofu</string>
+    <string name="icon_shape_ios">iOS</string>
+    <string name="icon_shape_squircle">Avrundet firkant</string>
+    <string name="icon_shape_xperia">Xperia</string>
+    <string name="icon_shape_riceballs">Risboller</string>
+
+    <string name="pref_drawer_type_title">Type appskuff</string>
+    <string name="drawer_type_frosted">Frostet</string>
+    <string name="drawer_type_mica">MICA</string>
+    <string name="drawer_type_translucent">Gjennomskinnelig</string>
+    <string name="pref_drawer_grid_width_override_title">Overstyr rutenettbredde</string>
+    <string name="pref_drawer_grid_width_override_summary">Bruk et egendefinert antall kolonner i appskuffen</string>
+
+    <string name="pref_blur_preview_title">Uskarp forhåndsvisning</string>
+    <string name="pref_blur_preview_desc">Gjør bakgrunnen uskarp når ikoner og moduler dras</string>
+    <string name="pref_double_tap_to_sleep_title">Dobbelttrykk for å låse</string>
+    <string name="pref_double_tap_to_sleep_summary">Dobbelttrykk på et tomt område for å låse skjermen</string>
+    <string name="pref_swipe_down_notifications_title">Sveip ned for varsler</string>
+    <string name="pref_swipe_down_notifications_summary">Sveip ned på startskjermen for å åpne varselpanelet</string>
+
+    <string name="murine_search_hint">Søk …</string>
+    <string name="murine_search_hint_provider">Søk med %1$s</string>
+    <string name="murine_search_hint_generic">Søk på nettet</string>
+    <string name="murine_search_button_desc">Søk</string>
+    <string name="murine_voice_search_desc">Talesøk</string>
+    <string name="murine_voice_search_prompt">Snakk nå …</string>
+    <string name="murine_lens_desc">Visuelt søk</string>
+    <string name="pref_qsb_show_search_bar_title">Vis søkefelt</string>
+    <string name="pref_qsb_search_provider_title">Søkeleverandør</string>
+    <string name="search_provider_custom">Egendefinert</string>
+    <string name="pref_qsb_enable_lens_title">Slå på Lens</string>
+    <string name="pref_qsb_enable_lens_summary">Vis Google Lens-knappen i hurtigsøket</string>
+    <string name="pref_qsb_box_blur">Gjør søkeboblen uskarp</string>
+    <string name="pref_qsb_box_blur_desc">Vis MICA-effekt for søkeboblen</string>
+    <string name="pref_qsb_bar_alpha">Gjennomsiktighet for søkefelt</string>
+    <string name="pref_qsb_box_alpha">Gjennomsiktighet for søkeboble</string>
+    <string name="pref_qsb_custom_provider_title">Egendefinert søkeadresse</string>
+    <string name="pref_qsb_history_size_title">Størrelse på søkehistorikk</string>
+    <string name="pref_qsb_history_size_summary">Maksimalt antall oppføringer</string>
+    <string name="pref_qsb_clear_history_title">Tøm søkehistorikk</string>
+    <string name="pref_qsb_clear_history_summary">Fjern alle lagrede søk</string>
+    <string name="pref_qsb_clear_history_confirm_title">Vil du tømme søkehistorikken?</string>
+    <string name="pref_qsb_clear_history_confirm_message">Dette fjerner alle lagrede søk permanent.</string>
+    <string name="pref_qsb_clear_history_toast">Søkehistorikken er tømt</string>
+
+    <string name="smartspace_mode_clock">Klokke</string>
+    <string name="smartspace_mode_google">Google Smartspace</string>
+    <string name="smartspace_mode_disabled">Deaktivert</string>
+    <string name="pref_smartspace_title">Modul på første skjerm</string>
+    <string name="pref_smartspace_summary_clock">Viser en klokke med dagens dato</string>
+    <string name="pref_smartspace_summary_google">Viser Google Smartspace-modulen</string>
+    <string name="pref_smartspace_summary_disabled">Ingen modul på den første skjermen</string>
+
+    <string name="pref_blur_unsupported_warning"><![CDATA[Uskarp bakgrunn støttes eller aktiveres kanskje ikke fullt ut av denne produsenten/ROM-en. Hvis du får problemer, kan du se etter «Tillat uskarphet på vindusnivå» under skjerm- eller utvikleralternativene.<br/>På enheter med root kan du alternativt prøve å aktivere <a href="https://github.com/Magisk-Modules-Alt-Repo/enable-blurs">denne Magisk-modulen</a>.]]></string>
+
+    <string name="pref_notification_badge_count_title">Antall varsler</string>
+    <string name="pref_notification_badge_count_desc">Vis antallet på varselprikker</string>
+
+    <string name="pref_category_icon_pack_title">Ikonpakke</string>
+    <string name="pref_category_icon_pack_summary">Endre appikoner med ikonpakker fra tredjeparter</string>
+    <string name="pref_icon_pack_system_only_title">Bare systemapper</string>
+    <string name="pref_icon_pack_system_only_summary">Bruk ikonpakken bare på systemapper</string>
+    <string name="pref_icon_pack_ignore_shape_title">Ignorer pakkens form</string>
+    <string name="pref_icon_pack_ignore_shape_summary">Bruk launcherens ikonform i stedet for pakkens</string>
+    <string name="pref_icon_readapt_frame_title">Tilpass til rammen på nytt</string>
+    <string name="pref_icon_readapt_frame_summary">Forsøker å tilpasse ikoner uten tema til det valgte formområdet</string>
+    <string name="pref_icon_pack_themed_only_title">Bare ikoner med tema</string>
+    <string name="pref_icon_pack_themed_only_summary">La ikoner som ikke finnes i ikonpakken, være uendret</string>
+
+    <string name="pref_category_hidden_apps_title">Skjulte apper</string>
+    <string name="pref_category_hidden_apps_summary">Skjul apper fra appskuffen</string>
+    <string name="hidden_apps_label">Skjult</string>
+    <string name="hidden_apps_search_hint">Søk etter apper …</string>
+    <string name="pref_search_within_hidden_title">Søk blant skjulte apper</string>
+    <string name="pref_search_within_hidden_summary">Søk i appskuffen finner skjulte apper</string>
+
+    <string name="app_info_package">Pakkenavn</string>
+    <string name="app_info_version">Versjon</string>
+    <string name="app_info_version_value">%1$s (%2$d)</string>
+    <string name="app_info_last_update">Sist oppdatert</string>
+    <string name="app_info_source">Kilde</string>
+    <string name="app_info_source_system">System</string>
+    <string name="app_info_icon_pack_default">Standard (global)</string>
+    <string name="app_info_copied_toast">Kopiert til utklippstavlen</string>
+    <string name="app_info_icon_pack_show_all">Vis alle pakker</string>
+    <string name="app_info_edit_label">Rediger etikett</string>
+    <string name="icon_picker_search_hint">Søk etter ikoner …</string>
+
+    <string name="pref_clear_custom_icons_title">Fjern egendefinerte ikoner</string>
+    <string name="pref_clear_custom_icons_summary">Fjern alle appspesifikke overstyringer av ikonpakker</string>
+    <string name="pref_clear_custom_icons_summary_none">Ingen egendefinerte ikoner er angitt</string>
+    <string name="pref_clear_custom_icons_confirm_title">Vil du fjerne egendefinerte ikoner?</string>
+    <string name="pref_clear_custom_icons_confirm_message">Dette tilbakestiller alle appspesifikke ikonpakkevalg til den globale innstillingen.</string>
+    <string name="pref_clear_custom_icons_toast">Egendefinerte ikoner er fjernet</string>
+
+    <string name="pref_default_launcher_title">Standardlauncher</string>
+    <string name="pref_restart_title">Start på nytt</string>
+    <string name="pref_restart_summary">Start launcheren på nytt</string>
+</resources>

--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -150,7 +150,7 @@
         <item>@dimen/swipe_up_max_velocity</item>
     </array>
 
-    <string-array name="filtered_components" ></string-array>
+    <string-array name="filtered_components" translatable="false"></string-array>
 
     <!-- Swipe back to home related -->
     <dimen name="swipe_back_window_scale_x_margin">10dp</dimen>
@@ -222,7 +222,7 @@
          DO NOT ADD TO THIS LIST.  Apps should use the PROPERTY_SUPPORTS_MULTI_INSTANCE_SYSTEM_UI
          property to declare multi-instance support in V+. This resource should match the resource
          of the same name in SystemUI. -->
-    <string-array name="config_appsSupportMultiInstancesSplit">
+    <string-array name="config_appsSupportMultiInstancesSplit" translatable="false">
     </string-array>
 
     <!-- Used to differentiate between desktop and non-desktop devices. -->

--- a/res/values/strings_murine.xml
+++ b/res/values/strings_murine.xml
@@ -21,12 +21,28 @@
     <string name="pref_category_misc_desc">Other options</string>
 
     <string name="pref_subcategory_day_night">UI theme</string>
+    <string name="pref_subcategory_language">Language</string>
     <string name="pref_subcategory_layout">Layout</string>
     <string name="pref_subcategory_appearance">Appearance</string>
     <string name="pref_subcategory_persistency">Persistency</string>
     <string name="pref_subcategory_gestures">Gestures</string>
     <string name="pref_subcategory_options">Options</string>
     <string name="pref_subcategory_backup">Backup</string>
+
+    <string name="pref_language_title">Language</string>
+    <string name="pref_language_system">System default</string>
+    <string name="pref_language_norwegian">Norwegian</string>
+    <string name="pref_language_english">English</string>
+    <string-array name="pref_language_entries">
+        <item>@string/pref_language_system</item>
+        <item>@string/pref_language_norwegian</item>
+        <item>@string/pref_language_english</item>
+    </string-array>
+    <string-array name="pref_language_values" translatable="false">
+        <item>system</item>
+        <item>nb</item>
+        <item>en</item>
+    </string-array>
 
     <string name="backup_export_title">Export backup</string>
     <string name="backup_export_desc">Save layout, widgets and settings</string>
@@ -84,6 +100,7 @@
     <!-- Murine search bar preferences -->
     <string name="pref_qsb_show_search_bar_title">Show search bar</string>
     <string name="pref_qsb_search_provider_title">Search provider</string>
+    <string name="search_provider_custom">Custom</string>
     <string name="pref_qsb_enable_lens_title">Enable Lens</string>
     <string name="pref_qsb_enable_lens_summary">Show Google Lens button in quick search</string>
     <string name="pref_qsb_box_blur">Blur search bubble</string>

--- a/res/xml/murine_prefs_drawer.xml
+++ b/res/xml/murine_prefs_drawer.xml
@@ -22,7 +22,7 @@
     <PreferenceCategory android:title="@string/pref_drawer_type_title">
         <com.android.settingslib.widget.SegmentedButtonPreference
             android:key="pref_drawer_type"
-            android:title="Screen Mode" />
+            android:title="@string/pref_drawer_type_title" />
         <com.android.settingslib.widget.SpacePreference
             android:layout_height="6dp" />
 

--- a/res/xml/murine_prefs_general.xml
+++ b/res/xml/murine_prefs_general.xml
@@ -19,10 +19,20 @@
     xmlns:launcher="http://schemas.android.com/apk/res-auto"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <PreferenceCategory android:title="@string/pref_subcategory_language">
+        <ListPreference
+            android:key="pref_launcher_language"
+            android:title="@string/pref_language_title"
+            android:entries="@array/pref_language_entries"
+            android:entryValues="@array/pref_language_values"
+            android:defaultValue="system"
+            android:persistent="true" />
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="@string/pref_subcategory_day_night">
         <com.android.settingslib.widget.SegmentedButtonPreference
             android:key="pref_launcher_theme_day_night"
-            android:title="Screen Mode" />
+            android:title="@string/pref_subcategory_day_night" />
         <com.android.settingslib.widget.SpacePreference
             android:layout_height="12dp" />
         <SwitchPreferenceCompat

--- a/src/app/murinelauncher/i18n/LanguageOverride.kt
+++ b/src/app/murinelauncher/i18n/LanguageOverride.kt
@@ -1,0 +1,66 @@
+package app.murinelauncher.i18n
+
+import android.content.Context
+import android.content.res.Configuration
+import android.content.res.Resources
+import com.android.launcher3.LauncherFiles
+import java.util.Locale
+
+object LanguageOverride {
+    const val LANGUAGE_SYSTEM = "system"
+    const val LANGUAGE_NORWEGIAN = "nb"
+    const val LANGUAGE_ENGLISH = "en"
+    const val PREF_LANGUAGE = "pref_launcher_language"
+
+    @JvmStatic
+    fun getLanguage(context: Context): String =
+        context.getSharedPreferences(LauncherFiles.SHARED_PREFERENCES_KEY, Context.MODE_PRIVATE)
+            .getString(PREF_LANGUAGE, LANGUAGE_SYSTEM) ?: LANGUAGE_SYSTEM
+
+    @JvmStatic
+    fun setLanguage(context: Context, languageTag: String) {
+        context.getSharedPreferences(LauncherFiles.SHARED_PREFERENCES_KEY, Context.MODE_PRIVATE)
+            .edit()
+            .putString(PREF_LANGUAGE, languageTag)
+            .apply()
+        updateApplicationResources(context.applicationContext, languageTag)
+    }
+
+    @JvmStatic
+    @JvmOverloads
+    fun applyLocale(context: Context, prefContext: Context = context): Context {
+        val languageTag = getLanguage(prefContext)
+        if (languageTag == LANGUAGE_SYSTEM) return context
+
+        val configuration = Configuration(context.resources.configuration)
+        val locale = Locale.forLanguageTag(languageTag)
+        configuration.setLocale(locale)
+        configuration.setLayoutDirection(locale)
+        return context.createConfigurationContext(configuration)
+    }
+
+    @JvmStatic
+    fun isLocaleStale(context: Context): Boolean {
+        val selected = getLanguage(context)
+        val expected = if (selected == LANGUAGE_SYSTEM) {
+            Resources.getSystem().configuration.locales[0].toLanguageTag()
+        } else {
+            Locale.forLanguageTag(selected).toLanguageTag()
+        }
+        val current = context.resources.configuration.locales[0].toLanguageTag()
+        return current != expected
+    }
+
+    @Suppress("DEPRECATION")
+    private fun updateApplicationResources(context: Context, languageTag: String) {
+        val locale = if (languageTag == LANGUAGE_SYSTEM) {
+            Resources.getSystem().configuration.locales[0]
+        } else {
+            Locale.forLanguageTag(languageTag)
+        }
+        val configuration = Configuration(context.resources.configuration)
+        configuration.setLocale(locale)
+        configuration.setLayoutDirection(locale)
+        context.resources.updateConfiguration(configuration, context.resources.displayMetrics)
+    }
+}

--- a/src/app/murinelauncher/settings/SettingsGeneralFragment.kt
+++ b/src/app/murinelauncher/settings/SettingsGeneralFragment.kt
@@ -1,12 +1,15 @@
 package app.murinelauncher.settings
 
 import android.util.Log
+import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.SwitchPreferenceCompat
 import app.murinelauncher.graphics.WorkspaceBlurUtils
+import app.murinelauncher.i18n.LanguageOverride
 import app.murinelauncher.settings.common.AbstractSettingsFragment
 import app.murinelauncher.icons.IconPackManager
 import app.murinelauncher.theme.ThemeOverride
+import com.android.launcher3.Launcher
 import com.android.launcher3.LauncherAppState
 import com.android.launcher3.LauncherPrefs
 import com.android.launcher3.R
@@ -17,6 +20,7 @@ public final class SettingsGeneralFragment: AbstractSettingsFragment() {
 
     companion object {
         const val LAUNCHER_THEME_DAY_NIGHT: String = "pref_launcher_theme_day_night"
+        const val LAUNCHER_LANGUAGE: String = LanguageOverride.PREF_LANGUAGE
         const val BLUR_PREVIEW: String = "pref_blur_preview"
         const val BLUR_WARNING: String = "pref_blur_warning"
     }
@@ -32,6 +36,18 @@ public final class SettingsGeneralFragment: AbstractSettingsFragment() {
 
     override fun initPreference(preference: Preference, info: DisplayController.Info): Boolean {
         when (preference.key) {
+            LAUNCHER_LANGUAGE -> {
+                preference as ListPreference
+                preference.value = LanguageOverride.getLanguage(requireContext())
+                preference.summaryProvider = ListPreference.SimpleSummaryProvider.getInstance()
+                preference.setOnPreferenceChangeListener { _, newValue ->
+                    LanguageOverride.setLanguage(requireContext(), newValue as String)
+                    Launcher.ACTIVITY_TRACKER.getCreatedContext<Launcher>()?.recreate()
+                    tryRecreateActivity()
+                    true
+                }
+                return true
+            }
             LAUNCHER_THEME_DAY_NIGHT -> {
                 preference as SegmentedButtonPreference
                 preference.apply {

--- a/src/app/murinelauncher/settings/SettingsQsbFragment.kt
+++ b/src/app/murinelauncher/settings/SettingsQsbFragment.kt
@@ -71,7 +71,7 @@ public final class SettingsQsbFragment: AbstractSettingsFragment() {
                 preference as RadioGroupPreference
                 preference.asEnum(SearchProvider::class.java).apply {
                     setDefaultValue(LauncherPrefs.QSB_SEARCH_PROVIDER.defaultValue)
-                    setTextProvider { _, provider -> provider.displayName }
+                    setTextProvider { context, provider -> provider.getDisplayName(context) }
                     setIconProvider { ctx, provider -> AppCompatResources.getDrawable(ctx, provider.iconRes) }
                     setOnSelected { provider ->
                         customProviderPref?.isVisible = provider == SearchProvider.CUSTOM

--- a/src/app/murinelauncher/widget/search/MurineSearchBarView.kt
+++ b/src/app/murinelauncher/widget/search/MurineSearchBarView.kt
@@ -73,7 +73,7 @@ class MurineSearchBarView @JvmOverloads constructor(
             context.getString(R.string.murine_search_hint_generic)
         else context.getString(
             R.string.murine_search_hint_provider,
-            SearchProvider.current.displayName
+            SearchProvider.current.getDisplayName(context)
         )
     }
 

--- a/src/app/murinelauncher/widget/search/SearchProvider.kt
+++ b/src/app/murinelauncher/widget/search/SearchProvider.kt
@@ -74,6 +74,9 @@ enum class SearchProvider(
         return searchUrlTemplate
     }
 
+    fun getDisplayName(context: Context): String =
+        if (this == CUSTOM) context.getString(R.string.search_provider_custom) else displayName
+
     fun buildSearchIntent(context: Context, query: String): Intent {
         var uri: Uri
         try {

--- a/src/com/android/launcher3/BaseActivity.java
+++ b/src/com/android/launcher3/BaseActivity.java
@@ -182,7 +182,8 @@ public abstract class BaseActivity extends FragmentActivity implements ActivityC
 
     @Override
     protected void attachBaseContext(android.content.Context base) {
-        super.attachBaseContext(app.murinelauncher.theme.ThemeOverride.applyTheme(base));
+        super.attachBaseContext(app.murinelauncher.theme.ThemeOverride.applyTheme(
+                app.murinelauncher.i18n.LanguageOverride.applyLocale(base)));
     }
 
     @Override
@@ -240,6 +241,8 @@ public abstract class BaseActivity extends FragmentActivity implements ActivityC
         super.onStart();
         mEventCallbacks[EVENT_STARTED].executeAllAndClear();
         if (app.murinelauncher.theme.ThemeOverride.isThemeStale(this)) {
+            getWindow().getDecorView().post(this::recreate);
+        } else if (app.murinelauncher.i18n.LanguageOverride.isLocaleStale(this)) {
             getWindow().getDecorView().post(this::recreate);
         }
     }

--- a/src/com/android/launcher3/LauncherApplication.java
+++ b/src/com/android/launcher3/LauncherApplication.java
@@ -16,6 +16,7 @@
 package com.android.launcher3;
 
 import android.app.Application;
+import android.content.Context;
 import android.content.res.Configuration;
 
 import app.murinelauncher.icons.IconPackManager;
@@ -33,6 +34,11 @@ public class LauncherApplication extends Application {
 
     private volatile LauncherBaseAppComponent mAppComponent;
     private int mNightMode = Configuration.UI_MODE_NIGHT_UNDEFINED;
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(app.murinelauncher.i18n.LanguageOverride.applyLocale(base));
+    }
 
     @Override
     public void onCreate() {

--- a/src/com/android/launcher3/settings/SettingsActivity.java
+++ b/src/com/android/launcher3/settings/SettingsActivity.java
@@ -51,13 +51,16 @@ public class SettingsActivity extends FragmentActivity
 
     @Override
     protected void attachBaseContext(android.content.Context base) {
-        super.attachBaseContext(app.murinelauncher.theme.ThemeOverride.applyTheme(base));
+        super.attachBaseContext(app.murinelauncher.theme.ThemeOverride.applyTheme(
+                app.murinelauncher.i18n.LanguageOverride.applyLocale(base)));
     }
 
     @Override
     protected void onStart() {
         super.onStart();
         if (app.murinelauncher.theme.ThemeOverride.isThemeStale(this)) {
+            getWindow().getDecorView().post(this::recreate);
+        } else if (app.murinelauncher.i18n.LanguageOverride.isLocaleStale(this)) {
             getWindow().getDecorView().post(this::recreate);
         }
     }


### PR DESCRIPTION
## Summary

- add complete Norwegian Bokmål translations for Murine-specific UI
- add a language selector under General with System default, Norwegian, and English
- apply locale changes across launcher and settings activities
- localize remaining hard-coded custom search and settings labels

## Why

The existing Norwegian resources covered AOSP Launcher3 strings but omitted Murine-specific strings, causing a mixed Norwegian/English interface.

## Validation

- verified 340/340 translatable resources have Norwegian values
- `assembleAospWithoutQuickstepDebug`
- `testAospWithoutQuickstepDebugUnitTest`
- `assembleAospWithoutQuickstepRelease`
- installed the signed release APK on an Android 16 device
