### PR TITLE
Add uninstall action to app shortcut menus

### DIFF
--- a/quickstep/src/com/android/launcher3/uioverrides/QuickstepLauncher.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/QuickstepLauncher.java
@@ -497,9 +497,7 @@ public class QuickstepLauncher extends Launcher implements RecentsViewContainer,
         if (Flags.enableShortcutDontSuggestApp()) {
             shortcuts.add(DONT_SUGGEST_APP);
         }
-        if (Flags.enablePrivateSpace()) {
-            shortcuts.add(UNINSTALL_APP);
-        }
+        shortcuts.add(UNINSTALL_APP);
         if (BubbleAnythingFlagHelper.enableCreateAnyBubble()) {
             shortcuts.add(BUBBLE_SHORTCUT);
         }

--- a/src/com/android/launcher3/popup/SystemShortcut.java
+++ b/src/com/android/launcher3/popup/SystemShortcut.java
@@ -1,8 +1,8 @@
 package com.android.launcher3.popup;
 
 import static com.android.launcher3.logging.StatsLogManager.LauncherEvent.LAUNCHER_DISMISS_PREDICTION_UNDO;
+import static com.android.launcher3.logging.StatsLogManager.LauncherEvent.LAUNCHER_ITEM_DROPPED_ON_UNINSTALL;
 import static com.android.launcher3.logging.StatsLogManager.LauncherEvent.LAUNCHER_PRIVATE_SPACE_INSTALL_SYSTEM_SHORTCUT_TAP;
-import static com.android.launcher3.logging.StatsLogManager.LauncherEvent.LAUNCHER_PRIVATE_SPACE_UNINSTALL_SYSTEM_SHORTCUT_TAP;
 import static com.android.launcher3.logging.StatsLogManager.LauncherEvent.LAUNCHER_SYSTEM_SHORTCUT_APP_INFO_TAP;
 import static com.android.launcher3.logging.StatsLogManager.LauncherEvent.LAUNCHER_SYSTEM_SHORTCUT_DONT_SUGGEST_APP_TAP;
 import static com.android.launcher3.logging.StatsLogManager.LauncherEvent.LAUNCHER_SYSTEM_SHORTCUT_WIDGETS_TAP;
@@ -34,7 +34,6 @@ import com.android.launcher3.Utilities;
 import com.android.launcher3.allapps.PrivateProfileManager;
 import com.android.launcher3.model.data.ItemInfo;
 import com.android.launcher3.model.data.WorkspaceItemInfo;
-import com.android.launcher3.pm.UserCache;
 import com.android.launcher3.util.ActivityOptionsWrapper;
 import com.android.launcher3.util.ApiWrapper;
 import com.android.launcher3.util.ComponentKey;
@@ -361,19 +360,10 @@ public abstract class SystemShortcut<T extends ActivityContext> extends ItemInfo
                 if (originalView == null) {
                     return null;
                 }
-                if (!Flags.enablePrivateSpace()) {
-                    return null;
-                }
-                if (!UserCache.INSTANCE.get(originalView.getContext()).getUserInfo(
-                        itemInfo.user).isPrivate()) {
-                    // If app is not Private Space app.
-                    return null;
-                }
                 ComponentName cn = SecondaryDropTarget.getUninstallTarget(originalView.getContext(),
                         itemInfo);
                 if (cn == null) {
-                    // If component name is null, don't show uninstall shortcut.
-                    // System apps will have component name as null.
+                    // Only application items backed by a non-system package can be uninstalled.
                     return null;
                 }
                 return new UninstallApp(activityContext, itemInfo, originalView, cn);
@@ -385,7 +375,7 @@ public abstract class SystemShortcut<T extends ActivityContext> extends ItemInfo
         UninstallApp(T target, ItemInfo itemInfo, @NonNull View originalView,
                 @NonNull ComponentName cn) {
             super(R.drawable.ic_uninstall_no_shadow,
-                    R.string.uninstall_private_system_shortcut_label, target,
+                    R.string.uninstall_drop_target_label, target,
                     itemInfo, originalView);
             mComponentName = cn;
 
@@ -398,7 +388,7 @@ public abstract class SystemShortcut<T extends ActivityContext> extends ItemInfo
             mTarget.getStatsLogManager()
                     .logger()
                     .withItemInfo(mItemInfo)
-                    .log(LAUNCHER_PRIVATE_SPACE_UNINSTALL_SYSTEM_SHORTCUT_TAP);
+                    .log(LAUNCHER_ITEM_DROPPED_ON_UNINSTALL);
         }
     }
 

--- a/tests/src/com/android/launcher3/popup/SystemShortcutTest.java
+++ b/tests/src/com/android/launcher3/popup/SystemShortcutTest.java
@@ -21,7 +21,6 @@ import static android.platform.test.flag.junit.SetFlagsRule.DefaultInitValueType
 import static com.android.dx.mockito.inline.extended.ExtendedMockito.spyOn;
 import static com.android.launcher3.AbstractFloatingView.TYPE_SNACKBAR;
 import static com.android.launcher3.Flags.FLAG_ENABLE_DISMISS_PREDICTION_UNDO;
-import static com.android.launcher3.Flags.FLAG_ENABLE_PRIVATE_SPACE;
 import static com.android.launcher3.LauncherSettings.Favorites.CONTAINER_ALL_APPS;
 import static com.android.launcher3.LauncherSettings.Favorites.CONTAINER_HOTSEAT_PREDICTION;
 import static com.android.launcher3.LauncherSettings.Favorites.ITEM_TYPE_APPLICATION;
@@ -349,28 +348,29 @@ public class SystemShortcutTest {
 
 
     @Test
-    @DisableFlags(FLAG_ENABLE_PRIVATE_SPACE)
-    public void testUninstallGetShortcutWithPrivateSpaceOff() {
+    public void testUninstallGetShortcutWithNullItemInfo() {
         SystemShortcut systemShortcut = SystemShortcut.UNINSTALL_APP.getShortcut(
                 mTestContext, null, mView);
         Assert.assertNull(systemShortcut);
     }
 
     @Test
-    @EnableFlags(FLAG_ENABLE_PRIVATE_SPACE)
     public void testUninstallGetShortcutWithNonPrivateItemInfo() {
         mAppInfo = new AppInfo();
         mAppInfo.user = MAIN_HANDLE;
-        when(mUserIconInfo.isPrivate()).thenReturn(false);
+        mAppInfo.itemType = ITEM_TYPE_APPLICATION;
+        mAppInfo.intent = mIntent;
+        mAppInfo.componentName = new ComponentName(mTestContext, getClass());
+        when(mLauncherActivityInfo.getComponentName()).thenReturn(mAppInfo.componentName);
+        mApplicationInfo.flags = 0;
 
         SystemShortcut systemShortcut = SystemShortcut.UNINSTALL_APP.getShortcut(
                 mTestContext, mAppInfo, mView);
-        verify(mUserIconInfo).isPrivate();
-        Assert.assertNull(systemShortcut);
+        verify(mLauncherActivityInfo).getComponentName();
+        Assert.assertNotNull(systemShortcut);
     }
 
     @Test
-    @EnableFlags(FLAG_ENABLE_PRIVATE_SPACE)
     public void testUninstallGetShortcutWithSystemItemInfo() {
         mAppInfo = new AppInfo();
         mAppInfo.user = PRIVATE_HANDLE;
@@ -378,7 +378,6 @@ public class SystemShortcutTest {
         mAppInfo.intent = mIntent;
         mAppInfo.componentName = new ComponentName(mTestContext, getClass());
         when(mLauncherActivityInfo.getComponentName()).thenReturn(mAppInfo.componentName);
-        when(mUserIconInfo.isPrivate()).thenReturn(true);
         // System App
         mApplicationInfo.flags = 1;
 
@@ -389,14 +388,12 @@ public class SystemShortcutTest {
     }
 
     @Test
-    @EnableFlags(FLAG_ENABLE_PRIVATE_SPACE)
     public void testUninstallGetShortcutWithPrivateItemInfo() {
         mAppInfo = new AppInfo();
         mAppInfo.user = PRIVATE_HANDLE;
         mAppInfo.itemType = ITEM_TYPE_APPLICATION;
         mAppInfo.intent = mIntent;
         mAppInfo.componentName = new ComponentName(mTestContext, getClass());
-        when(mUserIconInfo.isPrivate()).thenReturn(true);
         when(mLauncherActivityInfo.getComponentName()).thenReturn(mAppInfo.componentName);
         // 3rd party app, not system app.
         mApplicationInfo.flags = 0;


### PR DESCRIPTION
## Summary

- show an Uninstall action for removable third-party apps in long-press menus
- support icons in both the app drawer and home screen
- keep system apps and non-application shortcuts excluded
- include the action in standard and Quickstep launcher variants
- update SystemShortcut tests for normal, system, and Private Space apps

## Why

The existing uninstall shortcut was restricted to Private Space apps even though the launcher already had a safe Android uninstall flow for regular apps.

## Validation

- `assembleAospWithoutQuickstepDebug`
- `testAospWithoutQuickstepDebugUnitTest`
- installed the resulting APK on an Android 16 device
