### PR TITLE
fix: handle crash when launcher tries to load different user profiles

### DIFF
--- a/AndroidManifest-common.xml
+++ b/AndroidManifest-common.xml
@@ -48,6 +48,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.EXPAND_STATUS_BAR" />
     <uses-permission android:name="android.permission.ACCESS_HIDDEN_PROFILES" />
+    <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS" />
 
     <!--
     Permissions required for read/write access to the workspace data. These permission name
@@ -64,7 +65,6 @@
         android:protectionLevel="signatureOrSystem"
         android:label="@string/permlab_write_settings"
         android:description="@string/permdesc_write_settings"/>
-
     <uses-permission android:name="${applicationId}.permission.READ_SETTINGS" />
     <uses-permission android:name="${applicationId}.permission.WRITE_SETTINGS" />
 

--- a/src/com/android/launcher3/model/LoaderTask.java
+++ b/src/com/android/launcher3/model/LoaderTask.java
@@ -730,7 +730,15 @@ public class LoaderTask implements Runnable {
             }
 
             // Query for the set of apps
-            final List<LauncherActivityInfo> apps = mLauncherApps.getActivityList(null, user);
+            List<LauncherActivityInfo> apps = null;
+            try {
+                apps = mLauncherApps.getActivityList(null, user);
+            } catch (SecurityException e) {
+                if (Process.myUserHandle().equals(user)) {
+                    throw e;
+                }
+                Log.e(TAG, "Failed to get activities for user " + user, e);
+            }
             // Fail if we don't have any apps
             if (apps == null || apps.isEmpty()) {
                 if (Process.myUserHandle().equals(user)) {


### PR DESCRIPTION
## Summary
Handle and continue app profile loading instead of crashing, also request correct permissions since certain phones will have:

 - Private Space (Own pixel hidden encrypted profile)
 - Any other different user profile/user
 - Work profile

## Evidence
[x] Run app on physical device